### PR TITLE
Rewrite Psalm integration

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -51,7 +51,36 @@ jobs:
           docker cp "$PWD/tests/server/soap.wsdl" "$(docker ps | grep nginx | cut -d' ' -f1):/var/www/html/soap.wsdl"
       - run: composer install
       - run: ./vendor/bin/phpunit
-      - run: ./vendor/bin/psalm
+
+
+  Psalm:
+    name: Psalm Static Analyzer
+    runs-on: ubuntu-latest
+    permissions:
+      # for github/codeql-action/upload-sarif to upload SARIF results
+      security-events: write
+    container:
+      image: 'byjg/php:8.3-cli'
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Composer
+        run: composer install
+
+      - name: Psalm
+        # Note: Ignoring error code 2, which just signals that some
+        # flaws were found, not that Psalm itself failed to run.
+        run: ./vendor/bin/psalm
+          --show-info=true
+          --report=psalm-results.sarif || [ $? = 2 ]
+
+      - name: Upload Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: psalm-results.sarif
+
 
   Documentation:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -77,7 +77,7 @@ jobs:
           --report=psalm-results.sarif || [ $? = 2 ]
 
       - name: Upload Analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: psalm-results.sarif
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,7 +59,8 @@ jobs:
       # for github/codeql-action/upload-sarif to upload SARIF results
       security-events: write
     container:
-      image: 'byjg/php:8.4-cli'
+      image: byjg/php:8.4-cli
+      options: --user root --privileged
 
     steps:
       - name: Git checkout


### PR DESCRIPTION
Rewrite Psalm integration

This PR changes a few things related to how Psalm and GitHub are integrated into the project:

- Run Psalm only once. It picks up the target PHP dialect from the Composer config file, so it should give identical results regardless of the used PHP version.
- Create a SARIF report from the findings.
- Upload that report into GitHub's CodeQL service, which then displays the changes to the found flaws in the pull request.
- Include informal findings (warnings) in the report, too. For normal use, this generates way too much noise, but with GitHub presenting the delta to the found flaws only, having these available is acceptable.
